### PR TITLE
feat: add issue labeler

### DIFF
--- a/.github/ISSUE_TEMPLATE/roadmap.yml
+++ b/.github/ISSUE_TEMPLATE/roadmap.yml
@@ -8,8 +8,8 @@
 name: Roadmap Entry
 description: Add a new entry to the roadmap
 type: task
-projects:
-  - LizardByte/22
+labels:
+  - needs-triage
 body:
   - type: markdown
     attributes:
@@ -27,7 +27,7 @@ body:
   - type: dropdown
     id: _repositories
     attributes:
-      label: What repo(s) does this item apply to?
+      label: Repositories
       description: Select the repo(s) this item applies to. You can select multiple repos.
       multiple: true
       options:
@@ -84,6 +84,48 @@ body:
         - LizardByte/uno
         - LizardByte/update-changelog-action
         - LizardByte/winget-pkgs
+  - type: dropdown
+    id: stack
+    attributes:
+      label: Languages/Skills/Technologies
+      description: |
+        Select the languages/skills/technologies needed to complete this item.
+        You can select multiple options.
+      multiple: true
+      options:
+        - Android
+        - Bash/Shell/Scripting
+        - C
+        - C++
+        - C#
+        - CMake
+        - CSS
+        - Docker
+        - Documentation
+        - FFMpeg
+        - git
+        - GitHub actions
+        - Go
+        - HTML
+        - iOS
+        - Java
+        - JavaScript
+        - Kotlin
+        - Legal/Licensing
+        - Linux
+        - Markdown
+        - macOS
+        - Objective-C
+        - packaging
+        - Python
+        - Rest API
+        - Ruby
+        - Rust
+        - SQL
+        - TypeScript
+        - Video encoding/decoding
+        - Vue
+        - Windows
   - type: textarea
     id: description
     attributes:
@@ -95,15 +137,32 @@ body:
     validations:
       required: true
   - type: dropdown
+    id: effort
+    attributes:
+      label: Estimated Effort
+      description: |
+        How much effort is required to complete this item?
+        - Small (1-2 days)
+        - Medium (3-5 days)
+        - Large (1-2 weeks)
+        - Extra Large (2+ weeks)
+      options:
+        - Small
+        - Medium
+        - Large
+        - Extra Large
+    validations:
+      required: true
+  - type: dropdown
     id: priority
     attributes:
       label: Priority
       description: What priority level should this roadmap item have?
       options:
-        - Critical (P0)
-        - High (P1)
-        - Medium (P2)
-        - Low (P3)
+        - Critical
+        - High
+        - Medium
+        - Low
     validations:
       required: true
   - type: dropdown
@@ -112,9 +171,9 @@ body:
       label: Target Milestone
       description: When do you expect this item to be completed?
       options:
-        - Short-term (next 1-3 months)
-        - Medium-term (3-6 months)
-        - Long-term (6+ months)
+        - 1-3 months
+        - 3-6 months
+        - 6+ months
     validations:
       required: true
   - type: textarea

--- a/.github/t_roadmap.yml
+++ b/.github/t_roadmap.yml
@@ -2,8 +2,8 @@
 name: Roadmap Entry
 description: Add a new entry to the roadmap
 type: task
-projects:
-  - LizardByte/22  # roadmap - https://github.com/orgs/LizardByte/projects/22
+labels:
+  - needs-triage
 body:
   - type: markdown
     attributes:
@@ -21,11 +21,53 @@ body:
   - type: dropdown
     id: _repositories
     attributes:
-      label: What repo(s) does this item apply to?
+      label: Repositories
       description: Select the repo(s) this item applies to. You can select multiple repos.
       multiple: true
       options:
         - TODO
+  - type: dropdown
+    id: stack
+    attributes:
+      label: Languages/Skills/Technologies
+      description: |
+        Select the languages/skills/technologies needed to complete this item.
+        You can select multiple options.
+      multiple: true
+      options:
+        - Android
+        - Bash/Shell/Scripting
+        - C
+        - C++
+        - C#
+        - CMake
+        - CSS
+        - Docker
+        - Documentation
+        - FFMpeg
+        - git
+        - GitHub actions
+        - Go
+        - HTML
+        - iOS
+        - Java
+        - JavaScript
+        - Kotlin
+        - Legal/Licensing
+        - Linux
+        - Markdown
+        - macOS
+        - Objective-C
+        - packaging
+        - Python
+        - Rest API
+        - Ruby
+        - Rust
+        - SQL
+        - TypeScript
+        - Video encoding/decoding
+        - Vue
+        - Windows
   - type: textarea
     id: description
     attributes:
@@ -35,15 +77,32 @@ body:
     validations:
       required: true
   - type: dropdown
+    id: effort
+    attributes:
+      label: Estimated Effort
+      description: |
+        How much effort is required to complete this item?
+        - Small (1-2 days)
+        - Medium (3-5 days)
+        - Large (1-2 weeks)
+        - Extra Large (2+ weeks)
+      options:
+        - Small
+        - Medium
+        - Large
+        - Extra Large
+    validations:
+      required: true
+  - type: dropdown
     id: priority
     attributes:
       label: Priority
       description: What priority level should this roadmap item have?
       options:
-        - Critical (P0)
-        - High (P1)
-        - Medium (P2)
-        - Low (P3)
+        - Critical
+        - High
+        - Medium
+        - Low
     validations:
       required: true
   - type: dropdown
@@ -52,9 +111,9 @@ body:
       label: Target Milestone
       description: When do you expect this item to be completed?
       options:
-        - Short-term (next 1-3 months)
-        - Medium-term (3-6 months)
-        - Long-term (6+ months)
+        - 1-3 months
+        - 3-6 months
+        - 6+ months
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/issue_labeler.yml
+++ b/.github/workflows/issue_labeler.yml
@@ -1,0 +1,61 @@
+---
+name: Issue labeler
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+
+permissions:
+  contents: read
+
+jobs:
+  label-component:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Parse issue form
+        uses: stefanbuck/github-issue-parser@v3
+        id: issue-parser
+        with:
+          template-path: .github/ISSUE_TEMPLATE/roadmap.yml
+
+      - name: Set repository labels
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@v3
+        with:
+          issue-form: ${{ steps.issue-parser.outputs.jsonString }}
+          section: _repositories
+          token: ${{ secrets.GH_BOT_TOKEN }}
+
+      - name: Set stack labels
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@v3
+        with:
+          issue-form: ${{ steps.issue-parser.outputs.jsonString }}
+          section: stack
+          token: ${{ secrets.GH_BOT_TOKEN }}
+
+      - name: Set effort labels
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@v3
+        with:
+          issue-form: ${{ steps.issue-parser.outputs.jsonString }}
+          section: effort
+          token: ${{ secrets.GH_BOT_TOKEN }}
+
+      - name: Set priority labels
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@v3
+        with:
+          issue-form: ${{ steps.issue-parser.outputs.jsonString }}
+          section: priority
+          token: ${{ secrets.GH_BOT_TOKEN }}
+
+      - name: Set milestone labels
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@v3
+        with:
+          issue-form: ${{ steps.issue-parser.outputs.jsonString }}
+          section: milestone
+          token: ${{ secrets.GH_BOT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -7,18 +7,24 @@ The roadmap consists of GitHub issues that outline future plans, improvements, a
 
 This central roadmap repository helps us:
 - Coordinate development efforts across multiple repositories
-- Establish clear priorities and timelines
 - Track dependencies between projects
 - Provide transparency about our development direction
+- Clearly describe ideas and goals about our projects, and make it easier for new contributors to get involved
 
 ## How It Works
 
 Roadmap items are maintained as GitHub issues in this repository. Each item includes:
 - Target repositories
-- Priority level
-- Timeline expectations
-- Dependencies
+- Languages/Skills/Technologies involved
 - Detailed description
+- Estimated effort
+- Priority level
+- Milestone estimate
+- Dependencies
+
+> [!NOTE]  
+> LizardByte projects are maintained by volunteers.
+> The roadmap is not a guarantee of future work, but rather a guide to our current priorities and goals.
 
 ## For Team Members
 


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
- Adds automatic issue labeler
- Add new sections to roadmap template
  - Languages/Skills/Technology
  - Estimated Effort
- README updated and clarified expectations around the work/projects
- Issues no longer automatically added to "project" by the issue template, they will now be added when a "planned" label is applied to them. This is controlled in the project workflow settings
- A "needs-triage" label will be added to new issues by default

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
